### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "autoprefixer": "6.3.x",
     "babel-cli": "6.6.x",
-    "babel-core": "6.7.x",
+    "babel-core": "6.10.4",
     "babel-loader": "6.2.x",
     "babel-preset-es2015": "6.6.x",
     "babel-preset-react": "6.5.x",


### PR DESCRIPTION
react-workshop is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:minimatch:20160620). 

Vulnerable module: `minimatch`
Introduced through: `babel-core`

This PR fixes the ReDoS vulnerability by upgrading `babel-core` to version 6.10.4

Check out the [Snyk test report](https://snyk.io/test/github/mistadikay/react-workshop) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
- get alerts if newly disclosed vulnerabilities affect this repo in the future. 
- generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team
